### PR TITLE
fix: automatic inventory rest after generating report

### DIFF
--- a/apps/web/src/features/almacen/schemas/warehouseReportSchema.ts
+++ b/apps/web/src/features/almacen/schemas/warehouseReportSchema.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 
 const warehouseItemSchema = z.object({
     id: z.string(),
+    inventoryItemId: z.string().optional(),
     sku: z.string().optional(),
     name: z.string().min(1, "Selecciona un item"),
     units: z.number().min(1, "Mínimo 1 unidad"),

--- a/apps/web/src/features/almacen/views/NewWarehouseReportView.tsx
+++ b/apps/web/src/features/almacen/views/NewWarehouseReportView.tsx
@@ -244,7 +244,7 @@ export const NewWarehouseReportPage: React.FC = () => {
                                         type="button"
                                         variant="secondary"
 
-                                        onClick={() => appendTool({ id: crypto.randomUUID(), name: '', units: 1, observations: '', evidences: [] })}
+                                        onClick={() => appendTool({ id: crypto.randomUUID(), inventoryItemId: '', sku: '', name: '', units: 1, observations: '', evidences: [] })}
                                         className="h-9"
                                     >
                                         <Plus className="w-4 h-4 mr-2" /> Agregar
@@ -257,14 +257,37 @@ export const NewWarehouseReportPage: React.FC = () => {
                                             <div className="grid grid-cols-12 gap-4">
                                                 <div className="col-span-12 md:col-span-5">
                                                     <Label className="mb-1.5 block text-xs text-gray-500">Herramienta</Label>
-                                                    <Select {...register(`herramientas.${index}.name`)} className="h-9">
-                                                        <option value="">Seleccionar...</option>
-                                                        {inventoryOptions.map((item) => (
-                                                            <option key={item._id} value={item.name}>
-                                                                {item.name} (Stock: {item.quantityOnHand})
-                                                            </option>
-                                                        ))}
-                                                    </Select>
+                                                    <Controller
+                                                        control={control}
+                                                        name={`herramientas.${index}.inventoryItemId`}
+                                                        render={({ field }) => (
+                                                            <Select
+                                                                value={field.value || ''}
+                                                                onChange={(event) => {
+                                                                    const selectedId = event.target.value;
+                                                                    field.onChange(selectedId);
+                                                                    const selectedItem = inventoryOptions.find((item) => item._id === selectedId);
+                                                                    setValue(`herramientas.${index}.name`, selectedItem?.name ?? '', { shouldValidate: true, shouldDirty: true });
+                                                                    setValue(`herramientas.${index}.sku`, selectedItem?.sku ?? '', { shouldDirty: true });
+                                                                }}
+                                                                className="h-9"
+                                                            >
+                                                                <option value="">Seleccionar...</option>
+                                                                {inventoryOptions.map((item) => (
+                                                                    <option key={item._id} value={item._id}>
+                                                                        {item.name} (Stock: {item.quantityOnHand})
+                                                                    </option>
+                                                                ))}
+                                                            </Select>
+                                                        )}
+                                                    />
+                                                    <input type="hidden" {...register(`herramientas.${index}.name`)} />
+                                                    <input type="hidden" {...register(`herramientas.${index}.sku`)} />
+                                                    {errors.herramientas?.[index]?.name?.message && (
+                                                        <p className="text-red-500 text-xs mt-1">
+                                                            {errors.herramientas?.[index]?.name?.message as string}
+                                                        </p>
+                                                    )}
                                                 </div>
                                                 <div className="col-span-6 md:col-span-2">
                                                     <Label className="mb-1.5 block text-xs text-gray-500">Unidades</Label>
@@ -318,7 +341,7 @@ export const NewWarehouseReportPage: React.FC = () => {
                                         type="button"
                                         variant="secondary"
 
-                                        onClick={() => appendPart({ id: crypto.randomUUID(), name: '', units: 1, observations: '', evidences: [] })}
+                                        onClick={() => appendPart({ id: crypto.randomUUID(), inventoryItemId: '', sku: '', name: '', units: 1, observations: '', evidences: [] })}
                                         className="h-9"
                                     >
                                         <Plus className="w-4 h-4 mr-2" /> Agregar
@@ -331,14 +354,37 @@ export const NewWarehouseReportPage: React.FC = () => {
                                             <div className="grid grid-cols-12 gap-4">
                                                 <div className="col-span-12 md:col-span-5">
                                                     <Label className="mb-1.5 block text-xs text-gray-500">Refacción</Label>
-                                                    <Select {...register(`refacciones.${index}.name`)} className="h-9">
-                                                        <option value="">Seleccionar...</option>
-                                                        {inventoryOptions.map((item) => (
-                                                            <option key={item._id} value={item.name}>
-                                                                {item.name} (Stock: {item.quantityOnHand})
-                                                            </option>
-                                                        ))}
-                                                    </Select>
+                                                    <Controller
+                                                        control={control}
+                                                        name={`refacciones.${index}.inventoryItemId`}
+                                                        render={({ field }) => (
+                                                            <Select
+                                                                value={field.value || ''}
+                                                                onChange={(event) => {
+                                                                    const selectedId = event.target.value;
+                                                                    field.onChange(selectedId);
+                                                                    const selectedItem = inventoryOptions.find((item) => item._id === selectedId);
+                                                                    setValue(`refacciones.${index}.name`, selectedItem?.name ?? '', { shouldValidate: true, shouldDirty: true });
+                                                                    setValue(`refacciones.${index}.sku`, selectedItem?.sku ?? '', { shouldDirty: true });
+                                                                }}
+                                                                className="h-9"
+                                                            >
+                                                                <option value="">Seleccionar...</option>
+                                                                {inventoryOptions.map((item) => (
+                                                                    <option key={item._id} value={item._id}>
+                                                                        {item.name} (Stock: {item.quantityOnHand})
+                                                                    </option>
+                                                                ))}
+                                                            </Select>
+                                                        )}
+                                                    />
+                                                    <input type="hidden" {...register(`refacciones.${index}.name`)} />
+                                                    <input type="hidden" {...register(`refacciones.${index}.sku`)} />
+                                                    {errors.refacciones?.[index]?.name?.message && (
+                                                        <p className="text-red-500 text-xs mt-1">
+                                                            {errors.refacciones?.[index]?.name?.message as string}
+                                                        </p>
+                                                    )}
                                                 </div>
                                                 <div className="col-span-6 md:col-span-2">
                                                     <Label className="mb-1.5 block text-xs text-gray-500">Unidades</Label>


### PR DESCRIPTION
This pull request updates the warehouse report form to improve how tools and parts are selected and managed. The main changes introduce a more robust way to link selected items to inventory records, ensuring that each selection is tied to a unique inventory item ID and automatically updates related fields like name and SKU. This helps prevent data inconsistencies and improves the user experience when filling out the form.

**Form field enhancements for tools and parts:**

* The schema for warehouse items now includes an optional `inventoryItemId` field, allowing each item to be uniquely associated with an inventory record.
* When adding a new tool or part, the initial object now includes empty `inventoryItemId` and `sku` fields to align with the updated schema and form logic. [[1]](diffhunk://#diff-202511ecdf886448cab434b01e7562832e1771e7f8f621dd9bdbb236a7cda642L247-R247) [[2]](diffhunk://#diff-202511ecdf886448cab434b01e7562832e1771e7f8f621dd9bdbb236a7cda642L321-R344)

**Improved selection and data binding:**

* The tool ("herramienta") and part ("refacción") selectors have been refactored to use a `Controller` component for managing the `inventoryItemId` field. When a user selects an item, the corresponding `name` and `sku` fields are automatically updated based on the selected inventory item, and these fields are stored as hidden inputs. This ensures data consistency and a better user experience. [[1]](diffhunk://#diff-202511ecdf886448cab434b01e7562832e1771e7f8f621dd9bdbb236a7cda642L260-R290) [[2]](diffhunk://#diff-202511ecdf886448cab434b01e7562832e1771e7f8f621dd9bdbb236a7cda642L334-R387)