### PR TITLE
feat(work-report): Redesign multi-activity selection UI with shadcn c…

### DIFF
--- a/apps/api/src/modules/templates/templates.types.ts
+++ b/apps/api/src/modules/templates/templates.types.ts
@@ -19,6 +19,7 @@ export interface TemplateSectionConfig {
 export interface Template {
   _id?: ObjectId;
   codigoMantenimiento?: string | null;
+  numeroActividad?: number; // Activity number from Excel column B
   tipoReporte: ReportType;
   subsistema: string;
   tipoMantenimiento: string;

--- a/apps/api/src/scripts/importTemplatesFromExcel.ts
+++ b/apps/api/src/scripts/importTemplatesFromExcel.ts
@@ -1,5 +1,8 @@
-import "dotenv/config";
 import path from "node:path";
+import dotenv from "dotenv";
+
+// Load .env from apps/api directory
+dotenv.config({ path: path.resolve(__dirname, "..", "..", ".env") });
 import * as XLSX from "xlsx";
 import { getTemplateCollection } from "../db/mongo";
 import type { Template } from "../modules/templates/templates.types";
@@ -66,9 +69,12 @@ async function main() {
         // C: Activity / Description / Nombre Corto
         // D: Frecuencia
 
-        const rawSubsistema = row["A"];
-        const activity = row["C"];
-        const frecuencia = row["D"];
+        const rawSubsistema = row["A"]; // Subsistema
+const codigoMantenimiento = row["B"]; // Código de mantenimiento (optional)
+const activity = row["C"]; // Actividad / Nombre corto
+const frecuencia = row["D"]; // Frecuencia
+
+
 
         // Propagate subsistema
         if (rawSubsistema && typeof rawSubsistema === 'string' && rawSubsistema.trim() !== "") {
@@ -117,21 +123,23 @@ async function main() {
           tipoMantenimiento: normalizedType,
           frecuencia: frecuenciaLabel,
           frecuenciaCodigo: frecuenciaCodigo,
+          numeroActividad: codigoMantenimiento ? Number(codigoMantenimiento) : undefined,
           nombreCorto: String(activity).trim(),
           descripcion: String(activity).trim(),
-          codigoMantenimiento: undefined, // Explicitly undefined as requested
+          codigoMantenimiento: codigoMantenimiento ? String(codigoMantenimiento).trim() : undefined,
           secciones: DEFAULT_SECCIONES,
           activo: true,
           createdAt: new Date(),
           updatedAt: new Date()
         };
 
-        // Upsert logic
+        // Upsert logic - use numeroActividad to differentiate activities with same name
         const uniqueFilter = {
             tipoReporte: template.tipoReporte,
             subsistema: template.subsistema,
             tipoMantenimiento: template.tipoMantenimiento,
             frecuenciaCodigo: template.frecuenciaCodigo,
+            numeroActividad: template.numeroActividad,
             nombreCorto: template.nombreCorto
         };
 

--- a/apps/web/components.json
+++ b/apps/web/components.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://ui.shadcn.com/schema.json",
+  "style": "new-york",
+  "rsc": true,
+  "tsx": true,
+  "tailwind": {
+    "config": "",
+    "css": "src/index.css",
+    "baseColor": "neutral",
+    "cssVariables": true,
+    "prefix": ""
+  },
+  "iconLibrary": "lucide",
+  "aliases": {
+    "components": "@/components",
+    "utils": "@/lib/utils",
+    "ui": "@/components/ui",
+    "lib": "@/lib",
+    "hooks": "@/hooks"
+  },
+  "registries": {}
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -11,11 +11,16 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",
+    "@radix-ui/react-checkbox": "^1.3.3",
+    "@radix-ui/react-label": "^2.1.8",
+    "@radix-ui/react-select": "^2.2.6",
+    "@radix-ui/react-slot": "^1.2.4",
     "@react-pdf/renderer": "^4.3.1",
     "@tailwindcss/postcss": "^4.1.17",
     "@tanstack/react-query": "^5.90.11",
     "@tanstack/react-query-devtools": "^5.91.1",
     "better-auth": "^1.4.4",
+    "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.554.0",
     "next": "^15.5.6",
@@ -35,6 +40,7 @@
     "globals": "^16.5.0",
     "postcss": "^8.5.6",
     "tailwindcss": "^4.1.17",
+    "tw-animate-css": "^1.4.0",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.46.3"
   }

--- a/apps/web/src/components/ui/badge.tsx
+++ b/apps/web/src/components/ui/badge.tsx
@@ -1,0 +1,46 @@
+import * as React from "react"
+import { Slot } from "@radix-ui/react-slot"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const badgeVariants = cva(
+  "inline-flex items-center justify-center rounded-full border px-2 py-0.5 text-xs font-medium w-fit whitespace-nowrap shrink-0 [&>svg]:size-3 gap-1 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive transition-[color,box-shadow] overflow-hidden",
+  {
+    variants: {
+      variant: {
+        default:
+          "border-transparent bg-primary text-primary-foreground [a&]:hover:bg-primary/90",
+        secondary:
+          "border-transparent bg-secondary text-secondary-foreground [a&]:hover:bg-secondary/90",
+        destructive:
+          "border-transparent bg-destructive text-white [a&]:hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
+        outline:
+          "text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+function Badge({
+  className,
+  variant,
+  asChild = false,
+  ...props
+}: React.ComponentProps<"span"> &
+  VariantProps<typeof badgeVariants> & { asChild?: boolean }) {
+  const Comp = asChild ? Slot : "span"
+
+  return (
+    <Comp
+      data-slot="badge"
+      className={cn(badgeVariants({ variant }), className)}
+      {...props}
+    />
+  )
+}
+
+export { Badge, badgeVariants }

--- a/apps/web/src/components/ui/button.tsx
+++ b/apps/web/src/components/ui/button.tsx
@@ -1,0 +1,60 @@
+import * as React from "react"
+import { Slot } from "@radix-ui/react-slot"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const buttonVariants = cva(
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground hover:bg-primary/90",
+        destructive:
+          "bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
+        outline:
+          "border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50",
+        secondary:
+          "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        ghost:
+          "hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+      size: {
+        default: "h-9 px-4 py-2 has-[>svg]:px-3",
+        sm: "h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5",
+        lg: "h-10 rounded-md px-6 has-[>svg]:px-4",
+        icon: "size-9",
+        "icon-sm": "size-8",
+        "icon-lg": "size-10",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+)
+
+function Button({
+  className,
+  variant,
+  size,
+  asChild = false,
+  ...props
+}: React.ComponentProps<"button"> &
+  VariantProps<typeof buttonVariants> & {
+    asChild?: boolean
+  }) {
+  const Comp = asChild ? Slot : "button"
+
+  return (
+    <Comp
+      data-slot="button"
+      className={cn(buttonVariants({ variant, size, className }))}
+      {...props}
+    />
+  )
+}
+
+export { Button, buttonVariants }

--- a/apps/web/src/components/ui/card.tsx
+++ b/apps/web/src/components/ui/card.tsx
@@ -1,0 +1,92 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Card({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card"
+      className={cn(
+        "bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-sm",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-header"
+      className={cn(
+        "@container/card-header grid auto-rows-min grid-rows-[auto_auto] items-start gap-2 px-6 has-data-[slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-6",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-title"
+      className={cn("leading-none font-semibold", className)}
+      {...props}
+    />
+  )
+}
+
+function CardDescription({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-description"
+      className={cn("text-muted-foreground text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+function CardAction({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-action"
+      className={cn(
+        "col-start-2 row-span-2 row-start-1 self-start justify-self-end",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardContent({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-content"
+      className={cn("px-6", className)}
+      {...props}
+    />
+  )
+}
+
+function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-footer"
+      className={cn("flex items-center px-6 [.border-t]:pt-6", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Card,
+  CardHeader,
+  CardFooter,
+  CardTitle,
+  CardAction,
+  CardDescription,
+  CardContent,
+}

--- a/apps/web/src/components/ui/checkbox.tsx
+++ b/apps/web/src/components/ui/checkbox.tsx
@@ -1,0 +1,32 @@
+"use client"
+
+import * as React from "react"
+import * as CheckboxPrimitive from "@radix-ui/react-checkbox"
+import { CheckIcon } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+function Checkbox({
+  className,
+  ...props
+}: React.ComponentProps<typeof CheckboxPrimitive.Root>) {
+  return (
+    <CheckboxPrimitive.Root
+      data-slot="checkbox"
+      className={cn(
+        "peer border-input dark:bg-input/30 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground dark:data-[state=checked]:bg-primary data-[state=checked]:border-primary focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive size-4 shrink-0 rounded-[4px] border shadow-xs transition-shadow outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
+        className
+      )}
+      {...props}
+    >
+      <CheckboxPrimitive.Indicator
+        data-slot="checkbox-indicator"
+        className="grid place-content-center text-current transition-none"
+      >
+        <CheckIcon className="size-3.5" />
+      </CheckboxPrimitive.Indicator>
+    </CheckboxPrimitive.Root>
+  )
+}
+
+export { Checkbox }

--- a/apps/web/src/components/ui/input.tsx
+++ b/apps/web/src/components/ui/input.tsx
@@ -1,0 +1,21 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Input({ className, type, ...props }: React.ComponentProps<"input">) {
+  return (
+    <input
+      type={type}
+      data-slot="input"
+      className={cn(
+        "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
+        "aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Input }

--- a/apps/web/src/components/ui/label.tsx
+++ b/apps/web/src/components/ui/label.tsx
@@ -1,0 +1,24 @@
+"use client"
+
+import * as React from "react"
+import * as LabelPrimitive from "@radix-ui/react-label"
+
+import { cn } from "@/lib/utils"
+
+function Label({
+  className,
+  ...props
+}: React.ComponentProps<typeof LabelPrimitive.Root>) {
+  return (
+    <LabelPrimitive.Root
+      data-slot="label"
+      className={cn(
+        "flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Label }

--- a/apps/web/src/components/ui/select.tsx
+++ b/apps/web/src/components/ui/select.tsx
@@ -1,0 +1,187 @@
+"use client"
+
+import * as React from "react"
+import * as SelectPrimitive from "@radix-ui/react-select"
+import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+function Select({
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Root>) {
+  return <SelectPrimitive.Root data-slot="select" {...props} />
+}
+
+function SelectGroup({
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Group>) {
+  return <SelectPrimitive.Group data-slot="select-group" {...props} />
+}
+
+function SelectValue({
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Value>) {
+  return <SelectPrimitive.Value data-slot="select-value" {...props} />
+}
+
+function SelectTrigger({
+  className,
+  size = "default",
+  children,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Trigger> & {
+  size?: "sm" | "default"
+}) {
+  return (
+    <SelectPrimitive.Trigger
+      data-slot="select-trigger"
+      data-size={size}
+      className={cn(
+        "border-input data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 dark:hover:bg-input/50 flex w-fit items-center justify-between gap-2 rounded-md border bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <SelectPrimitive.Icon asChild>
+        <ChevronDownIcon className="size-4 opacity-50" />
+      </SelectPrimitive.Icon>
+    </SelectPrimitive.Trigger>
+  )
+}
+
+function SelectContent({
+  className,
+  children,
+  position = "popper",
+  align = "center",
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Content>) {
+  return (
+    <SelectPrimitive.Portal>
+      <SelectPrimitive.Content
+        data-slot="select-content"
+        className={cn(
+          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border shadow-md",
+          position === "popper" &&
+            "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
+          className
+        )}
+        position={position}
+        align={align}
+        {...props}
+      >
+        <SelectScrollUpButton />
+        <SelectPrimitive.Viewport
+          className={cn(
+            "p-1",
+            position === "popper" &&
+              "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)] scroll-my-1"
+          )}
+        >
+          {children}
+        </SelectPrimitive.Viewport>
+        <SelectScrollDownButton />
+      </SelectPrimitive.Content>
+    </SelectPrimitive.Portal>
+  )
+}
+
+function SelectLabel({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Label>) {
+  return (
+    <SelectPrimitive.Label
+      data-slot="select-label"
+      className={cn("text-muted-foreground px-2 py-1.5 text-xs", className)}
+      {...props}
+    />
+  )
+}
+
+function SelectItem({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Item>) {
+  return (
+    <SelectPrimitive.Item
+      data-slot="select-item"
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+        className
+      )}
+      {...props}
+    >
+      <span className="absolute right-2 flex size-3.5 items-center justify-center">
+        <SelectPrimitive.ItemIndicator>
+          <CheckIcon className="size-4" />
+        </SelectPrimitive.ItemIndicator>
+      </span>
+      <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+    </SelectPrimitive.Item>
+  )
+}
+
+function SelectSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Separator>) {
+  return (
+    <SelectPrimitive.Separator
+      data-slot="select-separator"
+      className={cn("bg-border pointer-events-none -mx-1 my-1 h-px", className)}
+      {...props}
+    />
+  )
+}
+
+function SelectScrollUpButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollUpButton>) {
+  return (
+    <SelectPrimitive.ScrollUpButton
+      data-slot="select-scroll-up-button"
+      className={cn(
+        "flex cursor-default items-center justify-center py-1",
+        className
+      )}
+      {...props}
+    >
+      <ChevronUpIcon className="size-4" />
+    </SelectPrimitive.ScrollUpButton>
+  )
+}
+
+function SelectScrollDownButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollDownButton>) {
+  return (
+    <SelectPrimitive.ScrollDownButton
+      data-slot="select-scroll-down-button"
+      className={cn(
+        "flex cursor-default items-center justify-center py-1",
+        className
+      )}
+      {...props}
+    >
+      <ChevronDownIcon className="size-4" />
+    </SelectPrimitive.ScrollDownButton>
+  )
+}
+
+export {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectScrollDownButton,
+  SelectScrollUpButton,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+}

--- a/apps/web/src/components/ui/textarea.tsx
+++ b/apps/web/src/components/ui/textarea.tsx
@@ -1,0 +1,18 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
+  return (
+    <textarea
+      data-slot="textarea"
+      className={cn(
+        "border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 flex field-sizing-content min-h-16 w-full rounded-md border bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Textarea }

--- a/apps/web/src/features/reports/components/WorkReportPDF.tsx
+++ b/apps/web/src/features/reports/components/WorkReportPDF.tsx
@@ -1,6 +1,13 @@
 import React from 'react';
 import { Page, Text, View, Document, StyleSheet, Image } from '@react-pdf/renderer';
 
+export type ActivityPDFItem = {
+    nombre: string;
+    realizado?: boolean;
+    observaciones?: string;
+    evidenciasCount?: number;
+};
+
 export type WorkReportPDFProps = {
     values: {
         subsistema?: string;
@@ -9,9 +16,7 @@ export type WorkReportPDFProps = {
         turno?: string;
         frecuencia?: string;
         trabajadores?: string[];
-        inspeccionRealizada?: boolean;
-        observacionesActividad?: string;
-        evidenciasCount?: number;
+        actividadesRealizadas?: ActivityPDFItem[];
         herramientas?: string[];
         refacciones?: string[];
         observacionesGenerales?: string;
@@ -152,6 +157,38 @@ const styles = StyleSheet.create({
         color: '#9ca3af',
         fontStyle: 'italic',
     },
+    // Activity table styles
+    tableHeader: {
+        flexDirection: 'row',
+        backgroundColor: primaryColor,
+        borderTopLeftRadius: 6,
+        borderTopRightRadius: 6,
+    },
+    tableHeaderCell: {
+        color: 'white',
+        fontSize: 7,
+        fontWeight: 'bold',
+        paddingVertical: 4,
+        paddingHorizontal: 4,
+        textTransform: 'uppercase',
+    },
+    tableRow: {
+        flexDirection: 'row',
+        borderBottomWidth: 1,
+        borderBottomColor: '#d0d5ee',
+        backgroundColor: 'white',
+    },
+    tableCell: {
+        fontSize: 8,
+        color: primaryColor,
+        paddingVertical: 4,
+        paddingHorizontal: 4,
+        borderRightWidth: 1,
+        borderRightColor: '#d0d5ee',
+    },
+    tableCellLast: {
+        borderRightWidth: 0,
+    },
 });
 
 const formatDate = (dateStr?: string) => {
@@ -184,9 +221,7 @@ export const WorkReportPDF = ({ values }: WorkReportPDFProps) => {
         turno,
         frecuencia,
         trabajadores,
-        inspeccionRealizada,
-        observacionesActividad,
-        evidenciasCount,
+        actividadesRealizadas,
         herramientas,
         refacciones,
         observacionesGenerales,
@@ -196,6 +231,7 @@ export const WorkReportPDF = ({ values }: WorkReportPDFProps) => {
     } = values;
 
     const workersString = trabajadores?.map(formatName).join(', ') || '—';
+    const hasActivities = actividadesRealizadas && actividadesRealizadas.length > 0;
 
     return (
         <Document>
@@ -232,23 +268,43 @@ export const WorkReportPDF = ({ values }: WorkReportPDFProps) => {
                         </View>
                     </View>
 
-                    {/* Activity Section */}
+                    {/* Activities Table */}
                     <View style={styles.section}>
-                        <Text style={styles.sectionHeader}>ACTIVIDAD</Text>
-                        <View style={styles.sectionContent}>
-                            <View style={{ flexDirection: 'row', justifyContent: 'space-between', marginBottom: 5 }}>
-                                <Text style={{ fontSize: 9, fontWeight: 'bold', color: primaryColor }}>¿Inspección realizada?</Text>
-                                <Text style={{ fontSize: 9, fontWeight: 'bold', color: primaryColor }}>{inspeccionRealizada ? 'SÍ' : 'NO'}</Text>
-                            </View>
-                            <Text style={{ fontSize: 8, fontWeight: 'bold', color: '#777', marginBottom: 2 }}>OBSERVACIONES</Text>
-                            <View style={{ borderWidth: 1, borderColor: '#d0d5ee', padding: 5, minHeight: 30, borderRadius: 4 }}>
-                                <Text style={{ fontSize: 9, color: primaryColor }}>
-                                    {observacionesActividad && observacionesActividad.trim().length > 0 ? observacionesActividad : '—'}
-                                </Text>
-                            </View>
-                            <Text style={{ fontSize: 8, color: '#555', marginTop: 3 }}>
-                                Evidencias adjuntas: {evidenciasCount ?? 0} / 5
-                            </Text>
+                        {/* Table Header */}
+                        <View style={styles.tableHeader}>
+                            <Text style={[styles.tableHeaderCell, { flex: 2 }]}>ACTIVIDAD</Text>
+                            <Text style={[styles.tableHeaderCell, { width: 40, textAlign: 'center' }]}>SI/NO</Text>
+                            <Text style={[styles.tableHeaderCell, { flex: 1, textAlign: 'center' }]}>OBSERVACIONES</Text>
+                            <Text style={[styles.tableHeaderCell, { width: 50, textAlign: 'center' }]}>EVIDENCIAS</Text>
+                        </View>
+                        {/* Table Body */}
+                        <View style={{ borderWidth: 1, borderTopWidth: 0, borderColor: primaryColor, borderBottomLeftRadius: 6, borderBottomRightRadius: 6, overflow: 'hidden' }}>
+                            {hasActivities ? (
+                                actividadesRealizadas.map((act, idx) => (
+                                    <View key={idx} style={[styles.tableRow, idx === actividadesRealizadas.length - 1 && { borderBottomWidth: 0 }]}>
+                                        <View style={[styles.tableCell, { flex: 2 }]}>
+                                            <Text>{act.nombre}</Text>
+                                        </View>
+                                        <View style={[styles.tableCell, { width: 40, justifyContent: 'center', alignItems: 'center' }]}>
+                                            <Text style={{ fontSize: 7, fontWeight: 'bold', color: act.realizado ? '#15803d' : '#6b7280' }}>
+                                                {act.realizado ? 'SÍ' : 'NO'}
+                                            </Text>
+                                        </View>
+                                        <View style={[styles.tableCell, { flex: 1 }]}>
+                                            <Text style={{ fontSize: 7 }}>
+                                                {act.observaciones && act.observaciones.trim() ? act.observaciones : '—'}
+                                            </Text>
+                                        </View>
+                                        <View style={[styles.tableCell, styles.tableCellLast, { width: 50, justifyContent: 'center', alignItems: 'center' }]}>
+                                            <Text style={{ fontSize: 7 }}>{act.evidenciasCount ?? 0}</Text>
+                                        </View>
+                                    </View>
+                                ))
+                            ) : (
+                                <View style={{ padding: 10 }}>
+                                    <Text style={styles.emptyText}>No hay actividades registradas</Text>
+                                </View>
+                            )}
                         </View>
                     </View>
 
@@ -257,7 +313,7 @@ export const WorkReportPDF = ({ values }: WorkReportPDFProps) => {
                         <View style={styles.row}>
                             <View style={styles.col}>
                                 <Text style={styles.sectionHeader}>HERRAMIENTAS UTILIZADAS</Text>
-                                <View style={[styles.sectionContent, { minHeight: 50 }]}>
+                                <View style={[styles.sectionContent, { minHeight: 40 }]}>
                                     {herramientas && herramientas.length > 0 ? (
                                         herramientas.map((tool, idx) => (
                                             <Text key={idx} style={styles.listItem}>• {formatName(tool)}</Text>
@@ -269,7 +325,7 @@ export const WorkReportPDF = ({ values }: WorkReportPDFProps) => {
                             </View>
                             <View style={styles.col}>
                                 <Text style={styles.sectionHeader}>REFACCIONES UTILIZADAS</Text>
-                                <View style={[styles.sectionContent, { minHeight: 50 }]}>
+                                <View style={[styles.sectionContent, { minHeight: 40 }]}>
                                     {refacciones && refacciones.length > 0 ? (
                                         refacciones.map((part, idx) => (
                                             <Text key={idx} style={styles.listItem}>• {formatName(part)}</Text>
@@ -285,7 +341,7 @@ export const WorkReportPDF = ({ values }: WorkReportPDFProps) => {
                     {/* General Observations */}
                     <View style={styles.section}>
                         <Text style={styles.sectionHeader}>OBSERVACIONES GENERALES</Text>
-                        <View style={[styles.sectionContent, { minHeight: 50 }]}>
+                        <View style={[styles.sectionContent, { minHeight: 40 }]}>
                             <Text style={{ fontSize: 9, color: primaryColor }}>
                                 {observacionesGenerales && observacionesGenerales.trim().length > 0 ? observacionesGenerales : '—'}
                             </Text>
@@ -297,13 +353,13 @@ export const WorkReportPDF = ({ values }: WorkReportPDFProps) => {
                         <View style={styles.row}>
                             <View style={styles.col}>
                                 <Text style={[styles.sectionHeader, { textAlign: 'center' }]}>NOMBRE Y FIRMA DE SUPERVISOR</Text>
-                                <View style={[styles.sectionContent, { minHeight: 60, justifyContent: 'space-between' }]}>
+                                <View style={[styles.sectionContent, { minHeight: 50, justifyContent: 'space-between' }]}>
                                     <Text style={{ fontSize: 9, fontWeight: 'bold', color: primaryColor }}>
                                         {nombreResponsable || '—'}
                                     </Text>
-                                    <View style={{ borderTopWidth: 1, borderTopColor: '#999', borderStyle: 'dashed', height: 30, justifyContent: 'flex-end', alignItems: 'center', marginTop: 5 }}>
+                                    <View style={{ borderTopWidth: 1, borderTopColor: '#999', borderStyle: 'dashed', height: 25, justifyContent: 'flex-end', alignItems: 'center', marginTop: 5 }}>
                                         {firmaResponsable ? (
-                                            <Image src={firmaResponsable} style={{ height: 28, objectFit: 'contain' }} />
+                                            <Image src={firmaResponsable} style={{ height: 22, objectFit: 'contain' }} />
                                         ) : (
                                             <Text style={{ fontSize: 7, color: '#d1d5db' }}>Sin firma</Text>
                                         )}
@@ -312,7 +368,7 @@ export const WorkReportPDF = ({ values }: WorkReportPDFProps) => {
                             </View>
                             <View style={styles.col}>
                                 <Text style={[styles.sectionHeader, { textAlign: 'center' }]}>FECHA Y HORA DE TÉRMINO</Text>
-                                <View style={[styles.sectionContent, { minHeight: 60, justifyContent: 'center', alignItems: 'center' }]}>
+                                <View style={[styles.sectionContent, { minHeight: 50, justifyContent: 'center', alignItems: 'center' }]}>
                                     <Text style={{ fontSize: 10, fontWeight: 'bold', color: primaryColor }}>
                                         {fechaHoraTermino ? formatDate(fechaHoraTermino) : '—'}
                                     </Text>

--- a/apps/web/src/features/reports/components/WorkReportPreview.tsx
+++ b/apps/web/src/features/reports/components/WorkReportPreview.tsx
@@ -1,5 +1,12 @@
 import React from "react";
 
+export type ActivityPreview = {
+  nombre: string;
+  realizado?: boolean;
+  observaciones?: string;
+  evidenciasCount?: number;
+};
+
 export type WorkReportPreviewProps = {
   values: {
     subsistema?: string;
@@ -9,9 +16,7 @@ export type WorkReportPreviewProps = {
     frecuencia?: string;
     trabajadores?: string[];
 
-    inspeccionRealizada?: boolean;
-    observacionesActividad?: string;
-    evidenciasCount?: number;
+    actividadesRealizadas?: ActivityPreview[];
 
     herramientas?: string[];
     refacciones?: string[];
@@ -31,9 +36,7 @@ export function WorkReportPreview({ values }: WorkReportPreviewProps) {
     turno,
     frecuencia,
     trabajadores,
-    inspeccionRealizada,
-    observacionesActividad,
-    evidenciasCount,
+    actividadesRealizadas,
     herramientas,
     refacciones,
     observacionesGenerales,
@@ -53,25 +56,27 @@ export function WorkReportPreview({ values }: WorkReportPreviewProps) {
     });
   };
 
+  const hasActivities = actividadesRealizadas && actividadesRealizadas.length > 0;
+
   return (
     <div className="rounded-xl border bg-white shadow-sm p-4 sticky top-6">
       <h2 className="mb-3 text-sm font-semibold text-gray-700">
         Vista previa del reporte
       </h2>
 
-      {/* 1. Outer page & frame */}
+      {/* Outer page & frame */}
       <div className="relative mx-auto w-full max-w-[750px] aspect-[8.5/11] bg-[#153A7A] p-4 text-xs leading-relaxed shadow-md overflow-hidden">
         <div className="relative h-full w-full rounded-[24px] border-[3px] border-[#F0493B] bg-[#f5f7ff] overflow-hidden flex flex-col">
-          {/* 2. Watermark - Visible behind content */}
+          {/* Watermark */}
           <div className="pointer-events-none absolute inset-0 flex items-center justify-center z-0">
             <span className="select-none text-[90px] font-bold text-gray-400/20 rotate-[-25deg] tracking-wider">
               IMA SOLUCIONES
             </span>
           </div>
 
-          {/* Page content - Transparent wrapper */}
+          {/* Page content */}
           <div className="relative z-10 h-full w-full flex flex-col bg-transparent">
-            {/* 3. Header layout */}
+            {/* Header */}
             <div className="flex items-center justify-between px-6 pt-5 pb-3">
               <div className="h-10 w-32 flex items-center justify-start">
                 <img
@@ -80,9 +85,7 @@ export function WorkReportPreview({ values }: WorkReportPreviewProps) {
                   className="h-10 w-auto object-contain"
                   onError={(e) => {
                     e.currentTarget.style.display = "none";
-                    e.currentTarget.nextElementSibling?.classList.remove(
-                      "hidden",
-                    );
+                    e.currentTarget.nextElementSibling?.classList.remove("hidden");
                   }}
                 />
                 <div className="hidden h-10 w-28 bg-[#153A7A] text-white text-xs font-semibold rounded-md flex items-center justify-center">
@@ -99,14 +102,11 @@ export function WorkReportPreview({ values }: WorkReportPreviewProps) {
             <div className="mx-6 h-[2px] rounded-full bg-[#153A7A]" />
 
             <div className="flex-1 overflow-y-auto">
-              {/* 3. General data section */}
+              {/* General data section */}
               <div className="mt-4 space-y-2 px-6">
                 <div className="grid grid-cols-2 gap-4">
                   <LabeledPill label="SUBSISTEMA" value={subsistema} />
-                  <LabeledPill
-                    label="FECHA Y HORA"
-                    value={formatDate(fechaHoraInicio)}
-                  />
+                  <LabeledPill label="FECHA Y HORA" value={formatDate(fechaHoraInicio)} />
                 </div>
                 <div className="grid grid-cols-2 gap-4">
                   <LabeledPill label="UBICACIÓN" value={ubicacion} />
@@ -116,48 +116,57 @@ export function WorkReportPreview({ values }: WorkReportPreviewProps) {
                   <LabeledPill label="FRECUENCIA" value={frecuencia} />
                   <LabeledPill
                     label="TRABAJADORES INVOLUCRADOS"
-                    value={
-                      trabajadores && trabajadores.length > 0
-                        ? workersToString(trabajadores)
-                        : undefined
-                    }
+                    value={trabajadores && trabajadores.length > 0 ? workersToString(trabajadores) : undefined}
                   />
                 </div>
               </div>
 
-              {/* 4. Activity section */}
+              {/* Activities Table */}
               <section className="mt-5 px-6">
-                <div className="rounded-t-md bg-[#153A7A] px-3 py-1 text-[9px] font-semibold uppercase tracking-wide text-white">
-                  ACTIVIDAD
+                <div className="rounded-t-md bg-[#153A7A] px-3 py-1 text-[9px] font-semibold uppercase tracking-wide text-white flex">
+                  <span className="flex-1">ACTIVIDAD</span>
+                  <span className="w-12 text-center">SI/NO</span>
+                  <span className="w-24 text-center">OBSERVACIONES</span>
+                  <span className="w-16 text-center">EVIDENCIAS</span>
                 </div>
-                <div className="rounded-b-md border border-[#153A7A] bg-white px-3 py-2 text-[10px] text-[#153A7A] space-y-1">
-                  <div className="flex items-center justify-between">
-                    <span className="font-semibold">
-                      ¿Inspección realizada?
-                    </span>
-                    <span className="font-semibold">
-                      {inspeccionRealizada ? "SÍ" : "NO"}
-                    </span>
-                  </div>
-                  <div className="mt-1">
-                    <div className="text-[9px] font-semibold uppercase text-[#777]">
-                      OBSERVACIONES
+                <div className="rounded-b-md border border-[#153A7A] bg-white">
+                  {hasActivities ? (
+                    actividadesRealizadas.map((act, idx) => (
+                      <div
+                        key={idx}
+                        className={`flex items-stretch text-[9px] text-[#153A7A] ${
+                          idx > 0 ? "border-t border-[#d0d5ee]" : ""
+                        }`}
+                      >
+                        <div className="flex-1 px-2 py-2 font-medium">{act.nombre}</div>
+                        <div className="w-12 px-1 py-2 flex items-center justify-center border-l border-[#d0d5ee]">
+                          <span className={`px-1 py-0.5 rounded text-[8px] font-bold ${
+                            act.realizado ? "bg-green-100 text-green-700" : "bg-gray-100 text-gray-500"
+                          }`}>
+                            {act.realizado ? "SÍ" : "NO"}
+                          </span>
+                        </div>
+                        <div className="w-24 px-1 py-1 border-l border-[#d0d5ee] text-[8px] overflow-hidden">
+                          {act.observaciones && act.observaciones.trim() ? (
+                            <span className="line-clamp-2">{act.observaciones}</span>
+                          ) : (
+                            <span className="text-gray-400 italic">—</span>
+                          )}
+                        </div>
+                        <div className="w-16 px-1 py-2 flex items-center justify-center border-l border-[#d0d5ee]">
+                          <span className="text-[8px]">{act.evidenciasCount ?? 0}</span>
+                        </div>
+                      </div>
+                    ))
+                  ) : (
+                    <div className="px-3 py-4 text-center text-[9px] text-gray-400 italic">
+                      No hay actividades seleccionadas
                     </div>
-                    <div className="min-h-[40px] rounded border border-[#d0d5ee] bg-white px-2 py-1 whitespace-pre-wrap">
-                      {observacionesActividad &&
-                      observacionesActividad.trim().length > 0
-                        ? observacionesActividad
-                        : "—"}
-                    </div>
-                  </div>
-                  <div className="mt-1 flex justify-between text-[9px] text-[#555]">
-                    <span>Evidencias adjuntas:</span>
-                    <span>{evidenciasCount ?? 0} / 5</span>
-                  </div>
+                  )}
                 </div>
               </section>
 
-              {/* 5. Tools and spare parts sections */}
+              {/* Tools and spare parts */}
               <section className="mt-5 px-6">
                 <div className="grid grid-cols-2 gap-4">
                   {/* HERRAMIENTAS */}
@@ -165,7 +174,7 @@ export function WorkReportPreview({ values }: WorkReportPreviewProps) {
                     <div className="rounded-t-md bg-[#153A7A] px-3 py-1 text-[9px] font-semibold uppercase tracking-wide text-white">
                       HERRAMIENTAS UTILIZADAS
                     </div>
-                    <div className="min-h-[70px] rounded-b-md border border-[#153A7A] bg-white px-3 py-2 text-[10px] text-[#153A7A]">
+                    <div className="min-h-[50px] rounded-b-md border border-[#153A7A] bg-white px-3 py-2 text-[10px] text-[#153A7A]">
                       {herramientas && herramientas.length > 0 ? (
                         <ul className="list-disc pl-4">
                           {herramientas.map((tool) => (
@@ -173,7 +182,7 @@ export function WorkReportPreview({ values }: WorkReportPreviewProps) {
                           ))}
                         </ul>
                       ) : (
-                        "Ninguna"
+                        <span className="text-gray-400 italic">Ninguna</span>
                       )}
                     </div>
                   </div>
@@ -183,7 +192,7 @@ export function WorkReportPreview({ values }: WorkReportPreviewProps) {
                     <div className="rounded-t-md bg-[#153A7A] px-3 py-1 text-[9px] font-semibold uppercase tracking-wide text-white">
                       REFACCIONES UTILIZADAS
                     </div>
-                    <div className="min-h-[70px] rounded-b-md border border-[#153A7A] bg-white px-3 py-2 text-[10px] text-[#153A7A]">
+                    <div className="min-h-[50px] rounded-b-md border border-[#153A7A] bg-white px-3 py-2 text-[10px] text-[#153A7A]">
                       {refacciones && refacciones.length > 0 ? (
                         <ul className="list-disc pl-4">
                           {refacciones.map((item) => (
@@ -191,23 +200,22 @@ export function WorkReportPreview({ values }: WorkReportPreviewProps) {
                           ))}
                         </ul>
                       ) : (
-                        "Ninguna"
+                        <span className="text-gray-400 italic">Ninguna</span>
                       )}
                     </div>
                   </div>
                 </div>
               </section>
 
-              {/* 6. Observaciones generales */}
+              {/* Observaciones generales */}
               <section className="mt-5 px-6">
                 <div className="rounded-t-md bg-[#153A7A] px-3 py-1 text-[9px] font-semibold uppercase tracking-wide text-white">
                   OBSERVACIONES GENERALES
                 </div>
-                <div className="min-h-[80px] rounded-b-md border border-[#153A7A] bg-white px-3 py-2 text-[10px] text-[#153A7A] whitespace-pre-wrap">
-                  {observacionesGenerales &&
-                  observacionesGenerales.trim().length > 0
+                <div className="min-h-[50px] rounded-b-md border border-[#153A7A] bg-white px-3 py-2 text-[10px] text-[#153A7A] whitespace-pre-wrap">
+                  {observacionesGenerales && observacionesGenerales.trim().length > 0
                     ? observacionesGenerales
-                    : "—"}
+                    : <span className="text-gray-400 italic">—</span>}
                 </div>
               </section>
 
@@ -219,18 +227,11 @@ export function WorkReportPreview({ values }: WorkReportPreviewProps) {
                     <div className="rounded-t-md bg-[#153A7A] px-3 py-1 text-[9px] font-semibold uppercase tracking-wide text-white">
                       NOMBRE Y FIRMA DE SUPERVISOR
                     </div>
-                    <div className="rounded-b-md border border-[#153A7A] bg-white px-3 py-2 text-[10px] text-[#153A7A] flex flex-col justify-between min-h-[60px]">
-                      <div className="font-medium">
-                        {nombreResponsable || "—"}
-                      </div>
-                      <div className="mt-2 h-[24px] border-t border-dashed border-[#999] flex items-end justify-center">
-                        {/* optional tiny signature preview */}
+                    <div className="rounded-b-md border border-[#153A7A] bg-white px-3 py-2 text-[10px] text-[#153A7A] flex flex-col justify-between min-h-[50px]">
+                      <div className="font-medium">{nombreResponsable || "—"}</div>
+                      <div className="mt-2 h-[20px] border-t border-dashed border-[#999] flex items-end justify-center">
                         {firmaResponsable && (
-                          <img
-                            src={firmaResponsable}
-                            alt="Firma"
-                            className="h-6 object-contain"
-                          />
+                          <img src={firmaResponsable} alt="Firma" className="h-5 object-contain" />
                         )}
                       </div>
                     </div>
@@ -241,7 +242,7 @@ export function WorkReportPreview({ values }: WorkReportPreviewProps) {
                     <div className="rounded-t-md bg-[#153A7A] px-3 py-1 text-[9px] font-semibold uppercase tracking-wide text-white">
                       FECHA Y HORA DE TÉRMINO
                     </div>
-                    <div className="rounded-b-md border border-[#153A7A] bg-white px-3 py-2 text-[10px] text-[#153A7A] min-h-[60px] flex items-center justify-center font-medium">
+                    <div className="rounded-b-md border border-[#153A7A] bg-white px-3 py-2 text-[10px] text-[#153A7A] min-h-[50px] flex items-center justify-center font-medium">
                       {fechaHoraTermino ? formatDate(fechaHoraTermino) : "—"}
                     </div>
                   </div>
@@ -268,7 +269,7 @@ function LabeledPill({ label, value }: { label: string; value?: string }) {
   );
 }
 
-// Helpers for formatting mock values
+// Helpers
 function workersToString(workers: string[]) {
   return workers
     .map((w) => w.replace(/_/g, " ").replace(/\b\w/g, (l) => l.toUpperCase()))

--- a/apps/web/src/features/reports/schemas/workReportSchema.ts
+++ b/apps/web/src/features/reports/schemas/workReportSchema.ts
@@ -2,7 +2,8 @@ import { z } from "zod";
 
 export const activityDetailSchema = z.object({
   templateId: z.string(),
-  realizado: z.boolean(),
+  nombre: z.string(), // Activity name for display
+  realizado: z.boolean().default(true), // Auto-true when selected
   observaciones: z.string().optional(),
   evidencias: z.array(z.any()).optional(),
 });

--- a/apps/web/src/features/reports/views/NewWorkReportPage.tsx
+++ b/apps/web/src/features/reports/views/NewWorkReportPage.tsx
@@ -3,14 +3,31 @@ import { useRouter } from 'next/navigation';
 import { useTemplateFilters, useActivitiesBySubsystemAndFrequency } from '@/hooks/useTemplates';
 import { useCreateWorkReportMutation } from '@/hooks/useWorkReports';
 import { useWarehouseItems } from '@/hooks/useWarehouse';
-import { useForm, Controller, useFieldArray } from 'react-hook-form';
+import { useForm, Controller } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { Button } from '@/shared/ui/Button';
+
+// shadcn components
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+
+// Custom components
 import { MultiSelect } from '@/shared/ui/MultiSelect';
 import { SignaturePad } from '@/shared/ui/SignaturePad';
 import { ImageUpload } from '@/shared/ui/ImageUpload';
 import { workReportSchema, WorkReportFormValues } from '../schemas/workReportSchema';
-import { Save, Check, X, ArrowLeft } from 'lucide-react';
+import { Save } from 'lucide-react';
 import { Template } from '@/types/template';
 import { WorkReportPreview } from '../components/WorkReportPreview';
 
@@ -22,18 +39,27 @@ const mockWorkers = [
   { value: 'jose_hernandez', label: 'José Hernández' },
 ];
 
+interface ActivityWithDetails {
+  id: string;
+  name: string;
+  code?: string;
+  template: Template;
+  isSelected: boolean;
+  observaciones: string;
+  evidencias: File[];
+  expanded: boolean;
+}
+
 export const NewWorkReportPage: React.FC = () => {
   const router = useRouter();
-  const [selectedTemplate, setSelectedTemplate] = useState<Template | null>(null);
+  const [activitiesState, setActivitiesState] = useState<ActivityWithDetails[]>([]);
 
-  // --- Form Setup ---
   const {
     register,
     control,
     handleSubmit,
     watch,
     setValue,
-    reset,
     formState: { errors, isSubmitting },
   } = useForm<WorkReportFormValues>({
     resolver: zodResolver(workReportSchema) as any,
@@ -50,44 +76,30 @@ export const NewWorkReportPage: React.FC = () => {
     }
   });
 
-  const { fields, replace } = useFieldArray({
-    control,
-    name: "actividadesRealizadas"
-  });
-
-  // --- Watchers ---
   const fechaHoraInicio = watch('fechaHoraInicio');
   const subsistema = watch('subsistema');
   const frecuencia = watch('frecuencia');
 
-  // --- Data Fetching ---
-  // 1. Filters
   const { data: filtersData, isLoading: isLoadingFilters } = useTemplateFilters('work');
   const subsystems = filtersData?.subsistemas || [];
 
   const { data: freqData, isLoading: isLoadingFreq } = useTemplateFilters('work', subsistema || undefined);
   const frequencies = freqData?.frecuencias || [];
 
-  // 2. Activities (Templates)
   const { data: activities, isLoading: isLoadingActivities } = useActivitiesBySubsystemAndFrequency({
     tipoReporte: 'work',
     subsistema: subsistema || undefined,
     frecuenciaCodigo: frecuencia || undefined,
   });
 
-  // 3. Warehouse Items (Tools & Parts)
   const { data: inventoryItems } = useWarehouseItems({ status: 'active' });
   const toolsOptions = inventoryItems?.filter(i => i.category?.toLowerCase() === 'herramientas').map(i => ({ value: i.name, label: i.name })) || [];
   const partsOptions = inventoryItems?.filter(i => i.category?.toLowerCase() === 'refacciones').map(i => ({ value: i.name, label: i.name })) || [];
 
-  // --- Effects ---
-
-  // Auto-set start time on mount
   useEffect(() => {
     setValue('fechaHoraInicio', new Date().toISOString().slice(0, 16));
   }, [setValue]);
 
-  // Auto-calculate shift
   useEffect(() => {
     if (fechaHoraInicio) {
       const date = new Date(fechaHoraInicio);
@@ -99,76 +111,96 @@ export const NewWorkReportPage: React.FC = () => {
     }
   }, [fechaHoraInicio, setValue]);
 
-  // Reset selection when subsistema changes
   useEffect(() => {
-    setValue('frecuencia', '');
-    setSelectedTemplate(null);
-  }, [subsistema, setValue]);
+    setActivitiesState([]);
+  }, [subsistema, frecuencia]);
 
-  // Reset selection when frecuencia changes
   useEffect(() => {
-    setSelectedTemplate(null);
-  }, [frecuencia]);
+    if (activities && activities.length > 0) {
+      setActivitiesState(activities.map(act => ({
+        id: act.id,
+        name: act.name,
+        code: act.code,
+        template: act.template,
+        isSelected: false,
+        observaciones: '',
+        evidencias: [],
+        expanded: false,
+      })));
+    }
+  }, [activities]);
 
+  useEffect(() => {
+    const selected = activitiesState.filter(a => a.isSelected);
+    const formActivities = selected.map(a => ({
+      templateId: a.template._id || a.id,
+      nombre: a.name,
+      realizado: true,
+      observaciones: a.observaciones,
+      evidencias: a.evidencias,
+    }));
+    setValue('actividadesRealizadas', formActivities);
+    setValue('templateIds', selected.map(a => a.template._id || a.id));
+  }, [activitiesState, setValue]);
 
-  // --- Handlers ---
-
-  const handleSelectActivity = (activity: any) => {
-    const template = activity.template as Template;
-    setSelectedTemplate(template);
-
-    // Set template ID
-    setValue('templateIds', [template._id]);
-
-    // Set single activity in the list
-    replace([{
-      templateId: template._id,
-      realizado: false,
-      observaciones: '',
-      evidencias: []
-    }]);
+  const toggleActivity = (id: string) => {
+    setActivitiesState(prev => prev.map(a => 
+      a.id === id ? { ...a, isSelected: !a.isSelected, expanded: !a.isSelected } : a
+    ));
   };
 
-  const handleBackToSelection = () => {
-    setSelectedTemplate(null);
-    setValue('templateIds', []);
-    replace([]);
+  const toggleExpanded = (id: string) => {
+    setActivitiesState(prev => prev.map(a => 
+      a.id === id ? { ...a, expanded: !a.expanded } : a
+    ));
+  };
+
+  const updateActivityObservaciones = (id: string, value: string) => {
+    setActivitiesState(prev => prev.map(a => 
+      a.id === id ? { ...a, observaciones: value } : a
+    ));
+  };
+
+  const updateActivityEvidencias = (id: string, files: File[]) => {
+    setActivitiesState(prev => prev.map(a => 
+      a.id === id ? { ...a, evidencias: files } : a
+    ));
   };
 
   const createReportMutation = useCreateWorkReportMutation();
 
   const onSubmit = async (data: WorkReportFormValues) => {
-    // Auto-set end time
     const now = new Date();
     const offset = now.getTimezoneOffset() * 60000;
     const localISOTime = (new Date(now.getTime() - offset)).toISOString().slice(0, 16);
     data.fechaHoraTermino = localISOTime;
 
-    // Process evidences
+    const selectedActivitiesData = activitiesState.filter(a => a.isSelected);
     const actividadesConEvidencias = await Promise.all(
-      (data.actividadesRealizadas || []).map(async (act) => {
-        const evidencias = await Promise.all((act.evidencias || []).map(async (file: any) => {
-          if (file instanceof File) {
-            return new Promise<string>((resolve) => {
-              const reader = new FileReader();
-              reader.onloadend = () => resolve(reader.result as string);
-              reader.readAsDataURL(file);
-            });
-          }
-          return file;
+      selectedActivitiesData.map(async (act) => {
+        const evidencias = await Promise.all(act.evidencias.map(async (file: File) => {
+          return new Promise<string>((resolve) => {
+            const reader = new FileReader();
+            reader.onloadend = () => resolve(reader.result as string);
+            reader.readAsDataURL(file);
+          });
         }));
-        return { ...act, evidencias };
+        return {
+          templateId: act.template._id || act.id,
+          nombre: act.name,
+          realizado: true,
+          observaciones: act.observaciones,
+          evidencias,
+        };
       })
     );
 
     const payload = {
       ...data,
       actividadesRealizadas: actividadesConEvidencias,
-      templateIds: [selectedTemplate?._id],
-      tipoMantenimiento: selectedTemplate?.tipoMantenimiento || 'Preventivo'
+      templateIds: selectedActivitiesData.map(a => a.template._id || a.id),
+      tipoMantenimiento: selectedActivitiesData[0]?.template.tipoMantenimiento || 'Preventivo'
     };
-
-    console.log('Form Data Submitted:', payload);
 
     try {
       const result = await createReportMutation.mutateAsync(payload as any);
@@ -180,367 +212,320 @@ export const NewWorkReportPage: React.FC = () => {
     }
   };
 
-  // --- Render ---
-
-  // Watch values for preview
   const watchedValues = watch();
-
-  // Map form values to preview props
+  const selectedActivities = activitiesState.filter(a => a.isSelected);
+  
   const previewValues = {
     ...watchedValues,
-    // Map the first activity's data to the preview fields
-    inspeccionRealizada: watchedValues.actividadesRealizadas?.[0]?.realizado,
-    observacionesActividad: watchedValues.actividadesRealizadas?.[0]?.observaciones,
-    evidenciasCount: watchedValues.actividadesRealizadas?.[0]?.evidencias?.length || 0,
-    // Map workers to string array if needed, or keep as is if Preview expects strings
-    trabajadores: watchedValues.trabajadores,
+    actividadesRealizadas: selectedActivities.map(a => ({
+      nombre: a.name,
+      realizado: true,
+      observaciones: a.observaciones,
+      evidenciasCount: a.evidencias.length,
+    })),
     herramientas: watchedValues.herramientas,
     refacciones: watchedValues.refacciones,
   };
 
-  const inputClass = "w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500 transition-all";
-  const labelClass = "block text-sm font-medium text-gray-700 mb-1";
-  const sectionHeaderClass = "flex items-center gap-3 mb-6";
-  const numberBadgeClass = "w-8 h-8 rounded-full bg-blue-100 text-blue-600 flex items-center justify-center font-bold text-sm";
-  const sectionTitleClass = "text-lg font-semibold text-gray-800";
+  const hasSelectedActivities = selectedActivities.length > 0;
 
   return (
-    <div className="min-h-screen bg-gray-50 py-8 px-4 sm:px-6 lg:px-8 font-sans">
+    <div className="min-h-screen bg-background py-8 px-4 sm:px-6 lg:px-8">
       <div className="max-w-[1600px] mx-auto">
 
         {/* Page Header */}
         <div className="mb-8">
-          <h1 className="text-2xl font-bold text-gray-900">Formato de trabajo</h1>
-          <p className="text-gray-500 mt-1">Llena el formato de trabajo para registrar la actividad realizada.</p>
+          <h1 className="text-2xl font-bold text-foreground">Formato de trabajo proyecto AEROTREN AICM</h1>
+          <p className="text-muted-foreground mt-1">Selecciona las actividades realizadas y registra observaciones y evidencias.</p>
         </div>
 
         <div className="grid gap-8 lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)] xl:grid-cols-[minmax(0,1.2fr)_minmax(0,1fr)]">
 
           {/* Left Column: Form */}
-          <div className="space-y-6">
+          <form onSubmit={handleSubmit(onSubmit as any)} className="space-y-6">
 
-            {/* Phase 1: Selection */}
-            {!selectedTemplate && (
-              <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-6 animate-in fade-in slide-in-from-bottom-4 duration-500">
-                <div className={sectionHeaderClass}>
-                  <div className={numberBadgeClass}>1</div>
-                  <h2 className={sectionTitleClass}>Selección de Actividad</h2>
+            {/* 1. Datos Generales */}
+            <Card>
+              <CardHeader className="pb-4">
+                <div className="flex items-center gap-3">
+                  <div className="w-8 h-8 rounded-full bg-[#153A7A] text-white flex items-center justify-center text-sm font-bold">1</div>
+                  <CardTitle>Datos generales</CardTitle>
                 </div>
-
-                <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-                  <div>
-                    <label className={labelClass}>Subsistema</label>
-                    <select
-                      {...register('subsistema')}
-                      className={inputClass}
-                      disabled={isLoadingFilters}
-                    >
-                      <option value="">Seleccionar...</option>
-                      {subsystems.map(sub => (
-                        <option key={sub} value={sub}>{sub}</option>
-                      ))}
-                    </select>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <div className="space-y-4">
+                  <div className="space-y-2">
+                    <Label htmlFor="subsistema">Subsistema</Label>
+                    <Controller
+                      name="subsistema"
+                      control={control}
+                      render={({ field }) => (
+                        <Select onValueChange={field.onChange} value={field.value} disabled={isLoadingFilters}>
+                          <SelectTrigger className="w-full">
+                            <SelectValue placeholder="Seleccionar..." />
+                          </SelectTrigger>
+                          <SelectContent>
+                            {subsystems.map(sub => (
+                              <SelectItem key={sub} value={sub}>{sub}</SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+                      )}
+                    />
                   </div>
-
-                  <div>
-                    <label className={labelClass}>Frecuencia</label>
-                    <select
-                      {...register('frecuencia')}
-                      className={inputClass}
-                      disabled={!subsistema || isLoadingFreq}
-                    >
-                      <option value="">{subsistema ? 'Seleccionar...' : 'Selecciona un subsistema'}</option>
-                      {frequencies.map(freq => (
-                        <option key={freq.code} value={freq.code}>{freq.label}</option>
-                      ))}
-                    </select>
+                  <div className="space-y-2">
+                    <Label htmlFor="frecuencia">Frecuencia</Label>
+                    <Controller
+                      name="frecuencia"
+                      control={control}
+                      render={({ field }) => (
+                        <Select onValueChange={field.onChange} value={field.value} disabled={!subsistema || isLoadingFreq}>
+                          <SelectTrigger className="w-full">
+                            <SelectValue placeholder={subsistema ? 'Seleccionar...' : 'Selecciona un subsistema'} />
+                          </SelectTrigger>
+                          <SelectContent>
+                            {frequencies.map(freq => (
+                              <SelectItem key={freq.code} value={freq.code}>{freq.label}</SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+                      )}
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="ubicacion">Ubicación</Label>
+                    <Input {...register('ubicacion')} placeholder="Ej. Centro de Operación T2 PK N/A" className="w-full" />
+                  </div>
+                  <div className="space-y-2">
+                    <Label>Trabajadores Involucrados</Label>
+                    <Controller
+                      name="trabajadores"
+                      control={control}
+                      render={({ field }) => (
+                        <MultiSelect
+                          options={mockWorkers}
+                          value={field.value}
+                          onChange={field.onChange}
+                          placeholder="Seleccionar..."
+                        />
+                      )}
+                    />
                   </div>
                 </div>
+              </CardContent>
+            </Card>
 
-                {subsistema && frecuencia && (
-                  <div className="mt-8">
-                    <h3 className="text-sm font-medium text-gray-500 uppercase tracking-wider mb-4">Actividades Disponibles</h3>
-                    {isLoadingActivities ? (
-                      <div className="text-center py-8 text-gray-500">Cargando actividades...</div>
-                    ) : activities && activities.length > 0 ? (
-                      <div className="grid gap-3">
-                        {activities.map((activity) => (
-                          <button
-                            key={activity.id}
-                            type="button"
-                            onClick={() => handleSelectActivity(activity)}
-                            className="text-left w-full p-4 border border-gray-200 rounded-lg hover:border-blue-500 hover:bg-blue-50 transition-all group bg-white shadow-sm"
-                          >
-                            <div className="flex justify-between items-center">
-                              <span className="font-medium text-gray-800 group-hover:text-blue-700">{activity.name}</span>
-                              <span className="text-xs font-medium text-gray-500 bg-gray-100 px-2 py-1 rounded">{activity.code}</span>
-                            </div>
-                            <p className="text-xs text-gray-500 mt-1">{activity.template.tipoMantenimiento}</p>
-                          </button>
-                        ))}
-                      </div>
-                    ) : (
-                      <div className="text-center py-8 text-gray-500 border-2 border-dashed border-gray-200 rounded-lg">
-                        No se encontraron actividades para esta selección.
-                      </div>
+            {/* 2. Actividades */}
+            {subsistema && frecuencia && (
+              <Card>
+                <CardHeader className="pb-4">
+                  <div className="flex items-center gap-3">
+                    <div className="w-8 h-8 rounded-full bg-[#153A7A] text-white flex items-center justify-center text-sm font-bold">2</div>
+                    <CardTitle>Actividades</CardTitle>
+                    {hasSelectedActivities && (
+                      <Badge className="ml-auto bg-[#F0493B] hover:bg-[#F0493B]/90 text-white">
+                        {selectedActivities.length} seleccionada(s)
+                      </Badge>
                     )}
                   </div>
-                )}
-              </div>
+                </CardHeader>
+                <CardContent>
+                  {isLoadingActivities ? (
+                    <div className="text-center py-8 text-muted-foreground">Cargando actividades...</div>
+                  ) : activitiesState.length > 0 ? (
+                    <div className="border rounded-lg overflow-hidden">
+                      {/* Table Header */}
+                      <div className="grid grid-cols-[auto_1fr_80px_100px_80px] bg-[#153A7A] text-white text-xs font-semibold uppercase">
+                        <div className="p-3 flex items-center justify-center">
+                          <span className="sr-only">Seleccionar</span>
+                        </div>
+                        <div className="p-3">Actividad</div>
+                        <div className="p-3 text-center">SI/NO</div>
+                        <div className="p-3 text-center">Observaciones</div>
+                        <div className="p-3 text-center">Evidencias</div>
+                      </div>
+
+                      {/* Table Rows */}
+                      {activitiesState.map((activity) => (
+                        <div key={activity.id} className="border-t">
+                          <div className={`grid grid-cols-[auto_1fr_80px_100px_80px] items-center ${
+                            activity.isSelected ? 'bg-blue-50' : 'bg-card hover:bg-muted/50'
+                          } transition-colors`}>
+                            <div className="p-3 flex items-center justify-center">
+                              <Checkbox
+                                checked={activity.isSelected}
+                                onCheckedChange={() => toggleActivity(activity.id)}
+                              />
+                            </div>
+                            <div className="p-3">
+                              <span className="text-sm">{activity.name}</span>
+                              {activity.code && (
+                                <span className="ml-2 text-xs text-muted-foreground">({activity.code})</span>
+                              )}
+                            </div>
+                            <div className="p-3 text-center">
+                              <Badge className={activity.isSelected ? 'bg-green-600 hover:bg-green-600 text-white' : 'bg-gray-200 text-gray-600'}>
+                                {activity.isSelected ? 'SÍ' : 'NO'}
+                              </Badge>
+                            </div>
+                            <div className="p-3 text-center">
+                              {activity.isSelected && (
+                                <Button
+                                  type="button"
+                                  variant="link"
+                                  size="sm"
+                                  onClick={() => toggleExpanded(activity.id)}
+                                  className="text-xs h-auto p-0"
+                                >
+                                  {activity.observaciones ? 'Editar' : 'Agregar'}
+                                </Button>
+                              )}
+                            </div>
+                            <div className="p-3 text-center">
+                              {activity.isSelected && (
+                                <span className="text-xs text-muted-foreground">
+                                  {activity.evidencias.length} / 5
+                                </span>
+                              )}
+                            </div>
+                          </div>
+
+                          {/* Expanded Detail Row */}
+                          {activity.isSelected && activity.expanded && (
+                            <div className="bg-blue-50 border-t border-blue-100 p-4">
+                              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                                <div className="space-y-2">
+                                  <Label>Observaciones</Label>
+                                  <Textarea
+                                    value={activity.observaciones}
+                                    onChange={(e) => updateActivityObservaciones(activity.id, e.target.value)}
+                                    placeholder="Escribe observaciones para esta actividad..."
+                                    rows={3}
+                                  />
+                                </div>
+                                <div className="space-y-2">
+                                  <Label>Evidencias (máx. 5)</Label>
+                                  <ImageUpload
+                                    label=""
+                                    onChange={(files) => updateActivityEvidencias(activity.id, files)}
+                                    compact
+                                  />
+                                </div>
+                              </div>
+                            </div>
+                          )}
+                        </div>
+                      ))}
+                    </div>
+                  ) : (
+                    <div className="text-center py-8 text-muted-foreground border-2 border-dashed rounded-lg">
+                      No se encontraron actividades para esta selección.
+                    </div>
+                  )}
+                </CardContent>
+              </Card>
             )}
 
-            {/* Phase 2: Form */}
-            {selectedTemplate && (
-              <form onSubmit={handleSubmit(onSubmit as any)} className="space-y-6 animate-in fade-in slide-in-from-right-8 duration-500">
-
-                <div className="flex items-center justify-between bg-white p-4 rounded-xl border border-gray-200 shadow-sm">
+            {/* 3. Herramientas y refacciones */}
+            {hasSelectedActivities && (
+              <Card>
+                <CardHeader className="pb-4">
                   <div className="flex items-center gap-3">
-                    <Button type="button" variant="ghost" size="sm" onClick={handleBackToSelection} className="text-gray-500 hover:text-gray-900">
-                      <ArrowLeft className="w-4 h-4" />
-                    </Button>
-                    <div>
-                      <span className="block text-xs text-gray-500 uppercase tracking-wide">Actividad seleccionada</span>
-                      <span className="font-bold text-gray-900">{selectedTemplate.nombreCorto || selectedTemplate.descripcion}</span>
-                    </div>
+                    <div className="w-8 h-8 rounded-full bg-[#153A7A] text-white flex items-center justify-center text-sm font-bold">3</div>
+                    <CardTitle>Herramientas y refacciones</CardTitle>
                   </div>
-                </div>
-
-                {/* 1. Datos Generales */}
-                <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-6">
-                  <div className={sectionHeaderClass}>
-                    <div className={numberBadgeClass}>1</div>
-                    <h2 className={sectionTitleClass}>Datos generales</h2>
-                  </div>
-
-                  <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-                    <div>
-                      <label className={labelClass}>Subsistema</label>
-                      <div className="relative">
-                        <select {...register('subsistema')} className={`${inputClass} appearance-none bg-gray-50`} disabled>
-                          <option value={subsistema}>{subsistema}</option>
-                        </select>
-                      </div>
-                    </div>
-                    <div>
-                      <label className={labelClass}>Ubicación</label>
-                      <input type="text" {...register('ubicacion')} className={inputClass} placeholder="Ej. Estación A - Andén 2" />
-                    </div>
-                    <div>
-                      <label className={labelClass}>Fecha y hora de inicio</label>
-                      <input type="datetime-local" {...register('fechaHoraInicio')} className={inputClass} />
-                    </div>
-                    <div>
-                      <label className={labelClass}>Turno</label>
-                      <input type="text" {...register('turno')} readOnly className={`${inputClass} bg-gray-50`} />
-                    </div>
-                    <div>
-                      <label className={labelClass}>Frecuencia</label>
-                      <select {...register('frecuencia')} className={`${inputClass} appearance-none bg-gray-50`} disabled>
-                        <option value={frecuencia}>{frequencies.find(f => f.code === frecuencia)?.label || frecuencia}</option>
-                      </select>
-                    </div>
-                    <div className="md:col-span-2">
-                      <label className={labelClass}>Trabajadores</label>
+                </CardHeader>
+                <CardContent>
+                  <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                    <div className="space-y-2">
+                      <Label>Herramientas utilizadas</Label>
                       <Controller
-                        name="trabajadores"
+                        name="herramientas"
                         control={control}
                         render={({ field }) => (
                           <MultiSelect
-                            options={mockWorkers}
-                            value={field.value}
+                            options={toolsOptions}
+                            value={field.value || []}
                             onChange={field.onChange}
-                            placeholder="Seleccionar..."
-                            className="border-gray-300 rounded-lg"
+                            placeholder="Seleccionar herramientas..."
+                          />
+                        )}
+                      />
+                    </div>
+                    <div className="space-y-2">
+                      <Label>Refacciones utilizadas</Label>
+                      <Controller
+                        name="refacciones"
+                        control={control}
+                        render={({ field }) => (
+                          <MultiSelect
+                            options={partsOptions}
+                            value={field.value || []}
+                            onChange={field.onChange}
+                            placeholder="Seleccionar refacciones..."
                           />
                         )}
                       />
                     </div>
                   </div>
-                </div>
-
-                {/* 2. Actividad */}
-                {selectedTemplate.secciones?.actividad?.enabled && (
-                  <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-6">
-                    <div className={sectionHeaderClass}>
-                      <div className={numberBadgeClass}>2</div>
-                      <h2 className={sectionTitleClass}>Actividad</h2>
-                    </div>
-
-                    <div className="space-y-6">
-                      {fields.map((field, index) => (
-                        <div key={field.id} className="space-y-4">
-                          <div className="flex items-center gap-3">
-                            <Controller
-                              name={`actividadesRealizadas.${index}.realizado`}
-                              control={control}
-                              render={({ field: { value, onChange } }) => (
-                                <div className="flex items-center gap-3">
-                                  <input
-                                    type="checkbox"
-                                    id={`check-${index}`}
-                                    checked={value}
-                                    onChange={(e) => onChange(e.target.checked)}
-                                    className="w-5 h-5 text-blue-600 rounded border-gray-300 focus:ring-blue-500"
-                                  />
-                                  <label htmlFor={`check-${index}`} className="text-gray-700 font-medium cursor-pointer">
-                                    Inspección realizada
-                                  </label>
-                                </div>
-                              )}
-                            />
-                          </div>
-
-                          {/* Observaciones & Evidencias (Conditional on checked? Or always visible? Let's keep always visible for now but maybe styled cleaner) */}
-                          <div className="pl-8 space-y-4">
-                            <div>
-                              <label className={labelClass}>Observaciones</label>
-                              <textarea
-                                {...register(`actividadesRealizadas.${index}.observaciones`)}
-                                className={inputClass}
-                                rows={3}
-                                placeholder="Escribe tus observaciones aquí..."
-                              />
-                            </div>
-                            <div>
-                              <Controller
-                                name={`actividadesRealizadas.${index}.evidencias`}
-                                control={control}
-                                render={({ field }) => (
-                                  <ImageUpload label="Evidencias adjuntas" onChange={field.onChange} compact />
-                                )}
-                              />
-                            </div>
-                          </div>
-                        </div>
-                      ))}
-                    </div>
-                  </div>
-                )}
-
-                {/* 3. Herramientas y refacciones */}
-                {(selectedTemplate.secciones?.herramientas?.enabled || selectedTemplate.secciones?.refacciones?.enabled) && (
-                  <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-6">
-                    <div className={sectionHeaderClass}>
-                      <div className={numberBadgeClass}>3</div>
-                      <h2 className={sectionTitleClass}>Herramientas y refacciones</h2>
-                    </div>
-
-                    <div className="space-y-6">
-                      {selectedTemplate.secciones?.herramientas?.enabled && (
-                        <div>
-                          <label className={labelClass}>Herramientas utilizadas</label>
-                          <Controller
-                            name="herramientas"
-                            control={control}
-                            render={({ field }) => (
-                              <MultiSelect
-                                options={toolsOptions}
-                                value={field.value || []}
-                                onChange={field.onChange}
-                                placeholder="Seleccionar herramientas..."
-                                className="border-gray-300 rounded-lg"
-                              />
-                            )}
-                          />
-                        </div>
-                      )}
-                      {selectedTemplate.secciones?.refacciones?.enabled && (
-                        <div>
-                          <label className={labelClass}>Refacciones utilizadas</label>
-                          <Controller
-                            name="refacciones"
-                            control={control}
-                            render={({ field }) => (
-                              <MultiSelect
-                                options={partsOptions}
-                                value={field.value || []}
-                                onChange={field.onChange}
-                                placeholder="Seleccionar refacciones..."
-                                className="border-gray-300 rounded-lg"
-                              />
-                            )}
-                          />
-                        </div>
-                      )}
-                    </div>
-                  </div>
-                )}
-
-                {/* 4. Cierre */}
-                {(selectedTemplate.secciones?.observacionesGenerales?.enabled || selectedTemplate.secciones?.firmas?.enabled) && (
-                  <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-6">
-                    <div className={sectionHeaderClass}>
-                      <div className={numberBadgeClass}>4</div>
-                      <h2 className={sectionTitleClass}>Cierre del reporte</h2>
-                    </div>
-
-                    <div className="space-y-6">
-                      {selectedTemplate.secciones?.observacionesGenerales?.enabled && (
-                        <div>
-                          <label className={labelClass}>Observaciones Generales</label>
-                          <textarea
-                            {...register('observacionesGenerales')}
-                            rows={3}
-                            className={inputClass}
-                            placeholder="Comentarios generales..."
-                          />
-                        </div>
-                      )}
-
-                      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-                        {selectedTemplate.secciones?.firmas?.enabled && (
-                          <div>
-                            <label className={labelClass}>Nombre del Supervisor</label>
-                            <input
-                              type="text"
-                              {...register('nombreResponsable')}
-                              className={inputClass}
-                              placeholder="Nombre completo"
-                            />
-                            <div className="mt-4">
-                              <Controller
-                                name="firmaResponsable"
-                                control={control}
-                                render={({ field }) => (
-                                  <SignaturePad label="Firma del Supervisor" onChange={field.onChange} />
-                                )}
-                              />
-                            </div>
-                          </div>
-                        )}
-                        {selectedTemplate.secciones?.fechas?.enabled && (
-                          <div>
-                            <label className={labelClass}>Fecha y Hora de Término</label>
-                            <div className="p-4 bg-gray-50 rounded-lg border border-gray-200 text-center text-gray-500 text-sm">
-                              Se registrará automáticamente al guardar el reporte.
-                            </div>
-                          </div>
-                        )}
-                      </div>
-                    </div>
-                  </div>
-                )}
-
-                {/* Submit Button */}
-                <div className="flex justify-end pt-4">
-                  <Button
-                    type="submit"
-                    className="w-full md:w-auto px-8 py-3 text-base font-medium bg-blue-900 hover:bg-blue-800 text-white rounded-lg shadow-md transition-all"
-                    isLoading={isSubmitting}
-                  >
-                    <Save className="w-5 h-5 mr-2" />
-                    Guardar Reporte
-                  </Button>
-                </div>
-
-              </form>
+                </CardContent>
+              </Card>
             )}
-          </div>
+
+            {/* 4. Cierre */}
+            {hasSelectedActivities && (
+              <Card>
+                <CardHeader className="pb-4">
+                  <div className="flex items-center gap-3">
+                    <div className="w-8 h-8 rounded-full bg-[#153A7A] text-white flex items-center justify-center text-sm font-bold">4</div>
+                    <CardTitle>Cierre del reporte</CardTitle>
+                  </div>
+                </CardHeader>
+                <CardContent className="space-y-4">
+                  <div className="space-y-2">
+                    <Label>Observaciones Generales</Label>
+                    <Textarea
+                      {...register('observacionesGenerales')}
+                      placeholder="Comentarios generales del trabajo realizado..."
+                      rows={3}
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label>Nombre del Supervisor</Label>
+                    <Input
+                      {...register('nombreResponsable')}
+                      placeholder="Nombre completo"
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Controller
+                      name="firmaResponsable"
+                      control={control}
+                      render={({ field }) => (
+                        <SignaturePad label="Firma del Supervisor" onChange={field.onChange} />
+                      )}
+                    />
+                  </div>
+                </CardContent>
+              </Card>
+            )}
+
+            {/* Submit Button */}
+            {hasSelectedActivities && (
+              <div className="flex justify-end pt-4">
+                <Button type="submit" size="lg" disabled={isSubmitting} className="bg-[#153A7A] hover:bg-[#153A7A]/90 text-white">
+                  <Save className="w-5 h-5 mr-2" />
+                  {isSubmitting ? 'Guardando...' : 'Guardar Reporte'}
+                </Button>
+              </div>
+            )}
+
+          </form>
 
           {/* Right Column: Preview */}
           <div className="hidden lg:block">
             <div className="sticky top-8">
-              <WorkReportPreview values={previewValues} />
+              <WorkReportPreview values={previewValues as any} />
             </div>
           </div>
 

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1,1 +1,120 @@
 @import "tailwindcss";
+@import "tw-animate-css";
+
+@custom-variant dark (&:is(.dark *));
+
+@theme inline {
+  --radius-sm: calc(var(--radius) - 4px);
+  --radius-md: calc(var(--radius) - 2px);
+  --radius-lg: var(--radius);
+  --radius-xl: calc(var(--radius) + 4px);
+  --color-background: var(--background);
+  --color-foreground: var(--foreground);
+  --color-card: var(--card);
+  --color-card-foreground: var(--card-foreground);
+  --color-popover: var(--popover);
+  --color-popover-foreground: var(--popover-foreground);
+  --color-primary: var(--primary);
+  --color-primary-foreground: var(--primary-foreground);
+  --color-secondary: var(--secondary);
+  --color-secondary-foreground: var(--secondary-foreground);
+  --color-muted: var(--muted);
+  --color-muted-foreground: var(--muted-foreground);
+  --color-accent: var(--accent);
+  --color-accent-foreground: var(--accent-foreground);
+  --color-destructive: var(--destructive);
+  --color-border: var(--border);
+  --color-input: var(--input);
+  --color-ring: var(--ring);
+  --color-chart-1: var(--chart-1);
+  --color-chart-2: var(--chart-2);
+  --color-chart-3: var(--chart-3);
+  --color-chart-4: var(--chart-4);
+  --color-chart-5: var(--chart-5);
+  --color-sidebar: var(--sidebar);
+  --color-sidebar-foreground: var(--sidebar-foreground);
+  --color-sidebar-primary: var(--sidebar-primary);
+  --color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
+  --color-sidebar-accent: var(--sidebar-accent);
+  --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
+  --color-sidebar-border: var(--sidebar-border);
+  --color-sidebar-ring: var(--sidebar-ring);
+}
+
+:root {
+  --radius: 0.625rem;
+  --background: oklch(1 0 0);
+  --foreground: oklch(0.145 0 0);
+  --card: oklch(1 0 0);
+  --card-foreground: oklch(0.145 0 0);
+  --popover: oklch(1 0 0);
+  --popover-foreground: oklch(0.145 0 0);
+  --primary: oklch(0.205 0 0);
+  --primary-foreground: oklch(0.985 0 0);
+  --secondary: oklch(0.97 0 0);
+  --secondary-foreground: oklch(0.205 0 0);
+  --muted: oklch(0.97 0 0);
+  --muted-foreground: oklch(0.556 0 0);
+  --accent: oklch(0.97 0 0);
+  --accent-foreground: oklch(0.205 0 0);
+  --destructive: oklch(0.577 0.245 27.325);
+  --border: oklch(0.922 0 0);
+  --input: oklch(0.922 0 0);
+  --ring: oklch(0.708 0 0);
+  --chart-1: oklch(0.646 0.222 41.116);
+  --chart-2: oklch(0.6 0.118 184.704);
+  --chart-3: oklch(0.398 0.07 227.392);
+  --chart-4: oklch(0.828 0.189 84.429);
+  --chart-5: oklch(0.769 0.188 70.08);
+  --sidebar: oklch(0.985 0 0);
+  --sidebar-foreground: oklch(0.145 0 0);
+  --sidebar-primary: oklch(0.205 0 0);
+  --sidebar-primary-foreground: oklch(0.985 0 0);
+  --sidebar-accent: oklch(0.97 0 0);
+  --sidebar-accent-foreground: oklch(0.205 0 0);
+  --sidebar-border: oklch(0.922 0 0);
+  --sidebar-ring: oklch(0.708 0 0);
+}
+
+.dark {
+  --background: oklch(0.145 0 0);
+  --foreground: oklch(0.985 0 0);
+  --card: oklch(0.205 0 0);
+  --card-foreground: oklch(0.985 0 0);
+  --popover: oklch(0.205 0 0);
+  --popover-foreground: oklch(0.985 0 0);
+  --primary: oklch(0.922 0 0);
+  --primary-foreground: oklch(0.205 0 0);
+  --secondary: oklch(0.269 0 0);
+  --secondary-foreground: oklch(0.985 0 0);
+  --muted: oklch(0.269 0 0);
+  --muted-foreground: oklch(0.708 0 0);
+  --accent: oklch(0.269 0 0);
+  --accent-foreground: oklch(0.985 0 0);
+  --destructive: oklch(0.704 0.191 22.216);
+  --border: oklch(1 0 0 / 10%);
+  --input: oklch(1 0 0 / 15%);
+  --ring: oklch(0.556 0 0);
+  --chart-1: oklch(0.488 0.243 264.376);
+  --chart-2: oklch(0.696 0.17 162.48);
+  --chart-3: oklch(0.769 0.188 70.08);
+  --chart-4: oklch(0.627 0.265 303.9);
+  --chart-5: oklch(0.645 0.246 16.439);
+  --sidebar: oklch(0.205 0 0);
+  --sidebar-foreground: oklch(0.985 0 0);
+  --sidebar-primary: oklch(0.488 0.243 264.376);
+  --sidebar-primary-foreground: oklch(0.985 0 0);
+  --sidebar-accent: oklch(0.269 0 0);
+  --sidebar-accent-foreground: oklch(0.985 0 0);
+  --sidebar-border: oklch(1 0 0 / 10%);
+  --sidebar-ring: oklch(0.556 0 0);
+}
+
+@layer base {
+  * {
+    @apply border-border outline-ring/50;
+  }
+  body {
+    @apply bg-background text-foreground;
+  }
+}

--- a/apps/web/src/lib/utils.ts
+++ b/apps/web/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from "clsx"
+import { twMerge } from "tailwind-merge"
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs))
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
       },
       "devDependencies": {
         "prettier": "^3.6.2",
+        "ts-node": "^10.9.2",
         "turbo": "^2.6.1",
         "typescript": "5.9.2"
       },
@@ -253,11 +254,16 @@
       "version": "0.0.0",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
+        "@radix-ui/react-checkbox": "^1.3.3",
+        "@radix-ui/react-label": "^2.1.8",
+        "@radix-ui/react-select": "^2.2.6",
+        "@radix-ui/react-slot": "^1.2.4",
         "@react-pdf/renderer": "^4.3.1",
         "@tailwindcss/postcss": "^4.1.17",
         "@tanstack/react-query": "^5.90.11",
         "@tanstack/react-query-devtools": "^5.91.1",
         "better-auth": "^1.4.4",
+        "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "lucide-react": "^0.554.0",
         "next": "^15.5.6",
@@ -277,6 +283,7 @@
         "globals": "^16.5.0",
         "postcss": "^8.5.6",
         "tailwindcss": "^4.1.17",
+        "tw-animate-css": "^1.4.0",
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.46.3"
       }
@@ -364,6 +371,30 @@
       "version": "1.1.18",
       "resolved": "https://registry.npmjs.org/@better-fetch/fetch/-/fetch-1.1.18.tgz",
       "integrity": "sha512-rEFOE1MYIsBmoMJtQbl32PGHHXuG2hDxvEd7rUHE0vCBoFQVSDqaVs9hkZEtHCxRoY+CljXKFCOuJ8uxqw1LcA=="
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
     },
     "node_modules/@drizzle-team/brocli": {
       "version": "0.10.2",
@@ -1417,6 +1448,44 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@floating-ui/core": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.3.tgz",
+      "integrity": "sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.10"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.4.tgz",
+      "integrity": "sha512-OOchDgh4F2CchOX94cRVqhvy7b3AFb+/rQXyswmzmGakRfkMgoWVjfnLWkRirfLEfuD4ysVW16eXzwt3jHIzKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.7.3",
+        "@floating-ui/utils": "^0.2.10"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.6.tgz",
+      "integrity": "sha512-4JX6rEatQEvlmgU80wZyq9RT96HZJa88q8hp0pBd+LrczeDI4o6uA2M+uvxngVHo4Ihr8uibXxH6+70zhAFrVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.7.4"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
+      "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
+      "license": "MIT"
+    },
     "node_modules/@hono/node-server": {
       "version": "1.19.6",
       "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.6.tgz",
@@ -2257,6 +2326,948 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@radix-ui/number": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-1.1.1.tgz",
+      "integrity": "sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/primitive": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
+      "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-arrow": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.7.tgz",
+      "integrity": "sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-arrow/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-arrow/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-checkbox": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-checkbox/-/react-checkbox-1.3.3.tgz",
+      "integrity": "sha512-wBbpv+NQftHDdG86Qc0pIyXk5IR3tM8Vd0nWLKDcX8nNn4nXFOFwsKuqw2okA/1D/mpaAkmuyndrPJTYDNZtFw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-checkbox/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-checkbox/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collection": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.7.tgz",
+      "integrity": "sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collection/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collection/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
+      "integrity": "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-direction": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.1.tgz",
+      "integrity": "sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.11.tgz",
+      "integrity": "sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-escape-keydown": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dismissable-layer/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dismissable-layer/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-guards": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.3.tgz",
+      "integrity": "sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-scope": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.7.tgz",
+      "integrity": "sha512-t2ODlkXBQyn7jkl6TNaw/MtVEVvIGelJDCG41Okq/KwUsJBwQ4XVZsHAVUkK4mBv3ewiAS3PGuUWuY2BoK4ZUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-scope/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-scope/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-id": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.1.tgz",
+      "integrity": "sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-label": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-label/-/react-label-2.1.8.tgz",
+      "integrity": "sha512-FmXs37I6hSBVDlO4y764TNz1rLgKwjJMQ0EGte6F3Cb3f4bIuHB/iLa/8I9VKkmOy+gNHq8rql3j686ACVV21A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popper": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.2.8.tgz",
+      "integrity": "sha512-0NJQ4LFFUuWkE7Oxf0htBKS6zLkkjBH+hM1uk7Ng705ReR8m/uelduy1DBo0PyBXPKVnBA6YBlU94MBGXrSBCw==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.0.0",
+        "@radix-ui/react-arrow": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-use-rect": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1",
+        "@radix-ui/rect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popper/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popper/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-portal": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.9.tgz",
+      "integrity": "sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-portal/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-portal/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-presence": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.5.tgz",
+      "integrity": "sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.4.tgz",
+      "integrity": "sha512-9hQc4+GNVtJAIEPEqlYqW5RiYdrr8ea5XQ0ZOnD6fgru+83kqT15mq2OCcbe8KnjRZl5vF3ks69AKz3kh1jrhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-select": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-select/-/react-select-2.2.6.tgz",
+      "integrity": "sha512-I30RydO+bnn2PQztvo25tswPH+wFBjehVGtmagkU78yMdwTwVf12wnAOF+AeP8S2N8xD+5UPbGhkUfPyvT+mwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/number": "1.1.1",
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-visually-hidden": "1.2.3",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-select/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-select/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slot": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.4.tgz",
+      "integrity": "sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.1.tgz",
+      "integrity": "sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.2.tgz",
+      "integrity": "sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-effect-event": "0.0.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-effect-event": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.2.tgz",
+      "integrity": "sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-escape-keydown": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.1.1.tgz",
+      "integrity": "sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-callback-ref": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz",
+      "integrity": "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-previous": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.1.1.tgz",
+      "integrity": "sha512-2dHfToCj/pzca2Ck724OZ5L0EVrr3eHRNsG/b3xQJLA2hZpVCS99bLAX+hm1IHXDEnzU6by5z/5MIY794/a8NQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-rect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.1.1.tgz",
+      "integrity": "sha512-QTYuDesS0VtuHNNvMh+CjlKJ4LJickCMUAqjlE3+j8w+RlRpwyX3apEQKGFzbZGdo7XNG1tXa+bQqIE7HIXT2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/rect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-size": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.1.tgz",
+      "integrity": "sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-visually-hidden": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.2.3.tgz",
+      "integrity": "sha512-pzJq12tEaaIhqjbzpCuv/OypJY/BPavOofm+dbab+MHLajy277+1lLm6JFcGgF5eskJ6mquGirhXY2GD/8u8Ug==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-visually-hidden/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-visually-hidden/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/rect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.1.tgz",
+      "integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==",
+      "license": "MIT"
+    },
     "node_modules/@react-pdf/fns": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@react-pdf/fns/-/fns-3.1.2.tgz",
@@ -2773,6 +3784,34 @@
         "react": "^18 || ^19"
       }
     },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.12.tgz",
+      "integrity": "sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -2836,7 +3875,7 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
@@ -3167,6 +4206,19 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/acorn-walk": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/adler-32": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.3.1.tgz",
@@ -3209,12 +4261,31 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
+    },
+    "node_modules/aria-hidden": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
+      "integrity": "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/array-buffer-byte-length": {
       "version": "1.0.2",
@@ -3798,6 +4869,18 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/class-variance-authority": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz",
+      "integrity": "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "clsx": "^2.1.1"
+      },
+      "funding": {
+        "url": "https://polar.sh/cva"
+      }
+    },
     "node_modules/client-only": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
@@ -3890,6 +4973,13 @@
       "engines": {
         "node": ">=0.8"
       }
+    },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -4058,11 +5148,27 @@
         "node": ">=8"
       }
     },
+    "node_modules/detect-node-es": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
+      "license": "MIT"
+    },
     "node_modules/dfa": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/dfa/-/dfa-1.2.0.tgz",
       "integrity": "sha512-ED3jP8saaweFTjeGX8HQPjeC1YYyZs98jGNZx6IiBvxW7JG5v492kamAQB3m2wop07CvU/RQmzcKr6bgcC5D/Q==",
       "license": "MIT"
+    },
+    "node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
     },
     "node_modules/docs": {
       "resolved": "apps/docs",
@@ -5101,6 +6207,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-nonce": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
+      "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/get-proto": {
@@ -6312,6 +7427,13 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -7287,6 +8409,53 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
     },
+    "node_modules/react-remove-scroll": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.2.tgz",
+      "integrity": "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "react-remove-scroll-bar": "^2.3.7",
+        "react-style-singleton": "^2.2.3",
+        "tslib": "^2.1.0",
+        "use-callback-ref": "^1.3.3",
+        "use-sidecar": "^1.1.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-remove-scroll-bar": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz",
+      "integrity": "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==",
+      "license": "MIT",
+      "dependencies": {
+        "react-style-singleton": "^2.2.2",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-signature-canvas": {
       "version": "1.1.0-alpha.2",
       "resolved": "https://registry.npmjs.org/react-signature-canvas/-/react-signature-canvas-1.1.0-alpha.2.tgz",
@@ -7312,6 +8481,28 @@
         "@types/prop-types": {
           "optional": true
         },
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-style-singleton": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
+      "integrity": "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "get-nonce": "^1.0.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
         "@types/react": {
           "optional": true
         }
@@ -8144,6 +9335,50 @@
         "typescript": ">=4.8.4"
       }
     },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "license": "0BSD"
@@ -8269,6 +9504,16 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/tw-animate-css": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/tw-animate-css/-/tw-animate-css-1.4.0.tgz",
+      "integrity": "sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Wombosvideo"
+      }
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -8482,6 +9727,49 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/use-callback-ref": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
+      "integrity": "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-sidecar": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz",
+      "integrity": "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "detect-node-es": "^1.1.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -8496,6 +9784,13 @@
       "dependencies": {
         "base64-arraybuffer": "^1.0.2"
       }
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/vite-compatible-readable-stream": {
       "version": "3.6.1",
@@ -8668,6 +9963,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4"
+      }
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "devDependencies": {
     "prettier": "^3.6.2",
+    "ts-node": "^10.9.2",
     "turbo": "^2.6.1",
     "typescript": "5.9.2"
   },


### PR DESCRIPTION
…omponents

## Summary
Complete redesign of the work report creation form to support multi-activity selection with per-activity observations and evidence upload.

## Frontend Changes (apps/web)

### NewWorkReportPage.tsx
- Refactored to use shadcn/ui components (Card, Button, Input, Label, Textarea, Checkbox, Badge, Select)
- Implemented table-based multi-activity selection with checkboxes
- Added expandable detail rows for per-activity observations and evidence
- Simplified 'Datos Generales' section: Subsistema, Frecuencia, Ubicación, Trabajadores (full-width single-column layout)
- Removed manual date/time fields - auto-set on form load and submit
- Applied IMA brand colors (#153A7A blue, #F0493B red accent)
- SI/NO status auto-updates based on activity selection

### WorkReportPreview.tsx
- Updated to display activities in table format
- Shows per-activity: nombre, SI/NO status, observaciones, evidencias count

### WorkReportPDF.tsx
- Updated PDF generation to render activities table
- Columns: ACTIVIDAD, SI/NO, OBSERVACIONES, EVIDENCIAS

### workReportSchema.ts
- Added 'nombre' field to activityDetailSchema for display purposes
- Set 'realizado' default to true (selected = done)

### shadcn/ui Integration
- Installed and configured shadcn/ui with Tailwind v4
- Added components: button, card, checkbox, input, label, select, textarea, badge
- Added utility function (cn) in src/lib/utils.ts

## Backend Changes (apps/api)

### templates.types.ts
- Added 'numeroActividad' field to Template interface

### importTemplatesFromExcel.ts
- Fixed missing activities bug: activities with same name but different numbers were being overwritten
- Now uses 'numeroActividad' as part of unique key for upsert
- Result: 175 templates imported (was 153)

## Breaking Changes
- None - backwards compatible with existing data structure